### PR TITLE
feat: Freeze protobuf to solve compatibility

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,4 +11,5 @@ numpy==1.19.5
 pandas==1.3.4
 scipy==1.7.0
 tensorflow-cpu==2.5.0
+protobuf==3.20.1
 boto3==1.21.44


### PR DESCRIPTION
**Description**
To summarize, when trying to run alphafold code we are getting an error related to `tensorflow` as depicted below:
```
Traceback (most recent call last):
--
File "/app/alphafold/run_aws_alphafold.py", line 28, in <module>
from alphafold.model import model
File "/app/alphafold/alphafold/model/model.py", line 20, in <module>
from alphafold.model import features
File "/app/alphafold/alphafold/model/features.py", line 19, in <module>
from alphafold.model.tf import input_pipeline
File "/app/alphafold/alphafold/model/tf/input_pipeline.py", line 17, in <module>
from alphafold.model.tf import data_transforms
File "/app/alphafold/alphafold/model/tf/data_transforms.py", line 18, in <module>
from alphafold.model.tf import shape_helpers
File "/app/alphafold/alphafold/model/tf/shape_helpers.py", line 16, in <module>
import tensorflow.compat.v1 as tf
File "/opt/conda/lib/python3.7/site-packages/tensorflow/__init__.py", line 41, in <module>
from tensorflow.python.tools import module_util as _module_util
File "/opt/conda/lib/python3.7/site-packages/tensorflow/python/__init__.py", line 40, in <module>
from tensorflow.python.eager import context
File "/opt/conda/lib/python3.7/site-packages/tensorflow/python/eager/context.py", line 32, in <module>
from tensorflow.core.framework import function_pb2
File "/opt/conda/lib/python3.7/site-packages/tensorflow/core/framework/function_pb2.py", line 16, in <module>
from tensorflow.core.framework import attr_value_pb2 as tensorflow_dot_core_dot_framework_dot_attr__value__pb2
File "/opt/conda/lib/python3.7/site-packages/tensorflow/core/framework/attr_value_pb2.py", line 16, in <module>
from tensorflow.core.framework import tensor_pb2 as tensorflow_dot_core_dot_framework_dot_tensor__pb2
File "/opt/conda/lib/python3.7/site-packages/tensorflow/core/framework/tensor_pb2.py", line 16, in <module>
from tensorflow.core.framework import resource_handle_pb2 as tensorflow_dot_core_dot_framework_dot_resource__handle__pb2
File "/opt/conda/lib/python3.7/site-packages/tensorflow/core/framework/resource_handle_pb2.py", line 16, in <module>
from tensorflow.core.framework import tensor_shape_pb2 as tensorflow_dot_core_dot_framework_dot_tensor__shape__pb2
File "/opt/conda/lib/python3.7/site-packages/tensorflow/core/framework/tensor_shape_pb2.py", line 42, in <module>
serialized_options=None, file=DESCRIPTOR),
File "/opt/conda/lib/python3.7/site-packages/google/protobuf/descriptor.py", line 560, in __new__
_message.Message._CheckCalledFromGeneratedFile()
TypeError: Descriptors cannot not be created directly.
If this call came from a _pb2.py file, your generated code is out of date and must be regenerated with protoc >= 3.19.0.
If you cannot immediately regenerate your protos, some other possible workarounds are:
1. Downgrade the protobuf package to 3.20.x or lower.
2. Set PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=python (but this will use pure-Python parsing and will be much slower).
More information: https://developers.google.com/protocol-buffers/docs/news/2022-05-06#python-updates
```
More info on this error can be found here: 
https://github.com/protocolbuffers/protobuf/issues/10051